### PR TITLE
feat(hq): UI refresh + PM proposals + PDR

### DIFF
--- a/PDR.md
+++ b/PDR.md
@@ -1,0 +1,144 @@
+# PDR — Kiwy HQ (Project Management Command Center)
+
+## 1) Resumen ejecutivo
+Kiwy HQ es el centro de comando para operación de Qualiver: estado global, automatizaciones, riesgos, propuestas accionables de Kiwy y trazabilidad básica de solicitudes externas.
+
+Objetivo: que Juan vea cómo va todo, qué propone ejecutar Kiwy, y aprobar ejecución desde el panel.
+
+## 2) Problema
+La operación está fragmentada (cron outputs, chats, scripts, reportes sueltos). Se necesita un solo lugar para:
+- entender salud operativa rápida,
+- ver tokens/costo de actividad,
+- revisar señales de riesgo,
+- ejecutar acciones concretas aprobadas.
+
+## 3) Objetivos
+1. Visión ejecutiva en < 30s.
+2. Mostrar “qué va a hacer Kiwy” (no solo lo del equipo).
+3. Aprobar acciones desde UI con feedback de ejecución.
+4. Trazar solicitudes externas y alertas.
+5. Mantener diseño usable, no saturado.
+
+## 4) Usuarios
+- Owner (Juan): decisión y control.
+- Kiwy (operación autónoma): propone, ejecuta, reporta.
+
+## 5) Alcance funcional (actual)
+### Tabs
+- Overview: KPIs, tokens recientes, historial operativo.
+- Projects: propuestas de Kiwy + vista compacta por proyecto.
+- Team: miembros + solicitudes externas detectadas.
+- Skills: búsqueda y detalle clickeable.
+
+### Propuestas aprobables
+Botón “Aprobar y ejecutar” dispara backend y devuelve resultado.
+
+### Estado PM arriba
+- `Project Management · Qualiver`
+- Estado general + resumen ejecutivo.
+
+## 6) Acciones aprobables (actual mapping)
+En `hq/v1/server.py` (`ACTION_MAP`):
+- `run_ops_report_now`
+- `rerun_failed_crons`
+- `run_meeting_monitor_now`
+
+Flujo:
+1. UI `POST /api/approve`
+2. server ejecuta comando
+3. devuelve `ok/error + stdout/stderr`
+4. UI refresca resumen
+
+## 7) Arquitectura
+### Frontend
+- `hq/v1/index.html` (SPA vanilla JS + CSS)
+
+### Backend local
+- `hq/v1/server.py`
+  - `GET /api/summary`
+  - `POST /api/approve`
+
+### Data pipeline
+- `hq/v1/refresh_hq.py` genera `hq/v1/data/summary.json`
+- cron de snapshot cada 20 min:
+  - `HQ v1 - Refresh snapshot`
+
+### Fuentes
+- `openclaw cron list --json`
+- `openclaw cron runs --id ...`
+- `qualiver/qualiver_ops_report.py`
+- `qualiver/state/google_record_meetings_state.json`
+- `HEARTBEAT.md`
+- skills list + skills locales
+
+## 8) Modelo de datos (summary.json)
+- `pm`: título, estado, resumen, propuestas
+- `tokens`: totales y por actividad
+- `automation`: salud + historial
+- `ops`: KPIs + proyectos + tareas críticas
+- `meetings`: revisión y docs recientes
+- `skills`: all/ready/missing
+- `agents`: ids y jobs por agente
+- `team`: miembros + conversaciones parciales (relay requests)
+
+## 9) Requisitos UX/UI
+- Tema claro, limpio, no saturado.
+- Neon solo en detalles (acento, botones, progreso).
+- Sidebar colapsable usable (sin desbordes).
+- Jerarquía clara:
+  - Overview = general
+  - Projects = propuestas ejecutables
+- Feedback visual de ejecución:
+  - estado, salida breve, recarga automática.
+
+## 10) Requisitos no funcionales
+- Carga rápida (<2s local).
+- Tolerancia a fallos de fuentes (degrada sin romper UI).
+- Seguridad:
+  - acciones solo por backend mapeado (no comando libre desde UI).
+- Operación local (127.0.0.1:3340 por defecto).
+
+## 11) Estado actual
+- UI funcional por tabs.
+- Propuestas solo en Projects.
+- Tokens con visual de barras.
+- Skills clickeables.
+- API de aprobación operativa.
+- Repo GitHub listo:
+  - `https://github.com/JCsierra-Qualy/kiwy-hq`
+  - branch de trabajo: `kiwy/hq-ui-refresh`
+
+## 12) Gaps abiertos
+1. Conversaciones de equipo completas aún parciales (relay/log limitado).
+2. Auditoría formal de aprobaciones (historial persistente por user/action).
+3. Mejor contexto en salida de “Aprobar y ejecutar” (paso a paso).
+4. Mejor visualización de costo/tokens por periodo (día/semana).
+
+## 13) Roadmap recomendado
+### V1.1
+- Log de aprobaciones (`approvals.log`) con timestamp + resultado.
+- Filtros en historial (ok/error/reuniones/automatización).
+- Indicador “última acción ejecutada”.
+
+### V1.2
+- Módulo “Inbox externo” real (relay robusto).
+- Confirm modal previo a ejecutar.
+- Métricas de tokens por día/semana/actividad.
+
+### V1.3
+- Integración directa con GitHub issues/proyectos del HQ.
+- Panel de “playbooks” (acciones compuestas en 1 clic).
+
+## 14) Criterios de aceptación
+- [ ] Owner entiende estado global en <30s.
+- [ ] Puede aprobar acción desde Projects y ver resultado claro.
+- [ ] Tokens legibles por actividad.
+- [ ] Sidebar colapsa sin glitches.
+- [ ] No hay propuestas fuera de Projects.
+- [ ] Team muestra al menos miembros + solicitudes relay detectadas.
+
+## 15) KPIs del producto HQ
+- Tiempo a decisión (TTD) desde abrir HQ.
+- % propuestas aprobadas y ejecutadas sin error.
+- Reducción de crons en error.
+- Reducción de vencidas operativas tras acciones aprobadas.

--- a/v1/index.html
+++ b/v1/index.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="es"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>Kiwy HQ</title>
+<style>
+:root{--bg:#06110b;--bg2:#0b1b12;--panel:#0f2218;--line:#1f5a3f;--txt:#dbffe8;--mut:#86cda7;--neon:#35ff9f;--neon2:#7dffcb;--danger:#ff6b7a;--side:230px}
+*{box-sizing:border-box}body{margin:0;font-family:Inter,system-ui,Arial;color:var(--txt);background:radial-gradient(900px 500px at 90% -10%,#0f3a24 0,transparent 50%),linear-gradient(180deg,var(--bg),var(--bg2))}
+.app{display:grid;grid-template-columns:var(--side) 1fr;min-height:100vh}.app.c{--side:78px}
+aside{border-right:1px solid var(--line);padding:10px;background:#08160f}.brand{display:flex;align-items:center;gap:10px;padding:9px;border:1px solid var(--line);border-radius:12px;background:#0d1e15}.btn{margin-left:auto;background:#0d271a;border:1px solid #2c7a53;color:var(--txt);border-radius:10px;padding:6px 9px;cursor:pointer}
+.nav{margin-top:10px;display:flex;flex-direction:column;gap:8px}.n{display:flex;gap:10px;align-items:center;padding:10px;border:1px solid var(--line);border-radius:11px;background:#0c1d15;cursor:pointer}.n.a{border-color:var(--neon);box-shadow:0 0 0 1px #1d7a51 inset,0 0 10px #1d7a5144}.ico{width:22px;text-align:center}.app.c .lbl,.app.c .name{display:none}.app.c .n{justify-content:center}
+main{padding:14px}.top{background:linear-gradient(180deg,#0d2016,#0a1a12);border:1px solid var(--line);border-radius:14px;padding:12px}.top h1{margin:0;font-size:28px;color:var(--neon2);text-shadow:0 0 16px #2bffb544}.mut{font-size:12px;color:var(--mut)}
+.panel{display:none}.panel.on{display:block}.grid{display:grid;grid-template-columns:repeat(4,minmax(120px,1fr));gap:10px;margin-top:10px}.card{background:linear-gradient(180deg,#0f2419,#0b1c14);border:1px solid var(--line);border-radius:14px;padding:12px}.k{font-size:12px;color:var(--mut)}.v{font-size:24px;font-weight:800}.two{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-top:10px}
+table{width:100%;border-collapse:collapse;font-size:13px}th,td{padding:8px;border-bottom:1px solid #1f4e37;text-align:left}
+.row{padding:8px;border:1px solid #21563c;border-radius:10px;background:#0a1912;margin:8px 0}.btn2{background:linear-gradient(180deg,var(--neon2),var(--neon));border:1px solid #67ffbe;color:#042413;padding:7px 10px;border-radius:9px;font-weight:800;cursor:pointer}
+.bad{color:var(--danger)}.ok{color:var(--neon)}
+.bar{height:8px;background:#0a1a13;border:1px solid #1e4c36;border-radius:999px;overflow:hidden}.bar>span{display:block;height:100%;background:linear-gradient(90deg,#2fff9f,#7dffcb)}
+input{width:100%;padding:10px;border-radius:10px;border:1px solid #2b7a53;background:#08170f;color:var(--txt)}
+@media(max-width:1100px){.grid{grid-template-columns:repeat(2,minmax(110px,1fr))}.two{grid-template-columns:1fr}}
+</style></head>
+<body><div class="app" id="app"><aside>
+<div class="brand"><div>🥝</div><div class="name"><b>Kiwy HQ</b></div><button class="btn" id="t">☰</button></div>
+<div class="nav">
+  <div class="n a" data-p="overview"><div class="ico">🏠</div><div class="lbl">Overview</div></div>
+  <div class="n" data-p="projects"><div class="ico">📌</div><div class="lbl">Projects</div></div>
+  <div class="n" data-p="team"><div class="ico">👥</div><div class="lbl">Team</div></div>
+  <div class="n" data-p="skills"><div class="ico">🧩</div><div class="lbl">Skills</div></div>
+</div></aside>
+<main>
+<div class="top"><h1>Project Management · Qualiver</h1><div id="st" class="mut"></div><div id="sum" style="margin-top:6px;font-weight:700"></div></div>
+
+<section class="panel on" id="p-overview">
+  <div class="grid" id="top"></div>
+  <div class="two">
+    <div class="card"><h3>Tokens recientes</h3><div id="tokMeta" class="mut"></div><div id="tokRows"></div></div>
+    <div class="card"><h3>Historial operativo</h3><table><thead><tr><th>Estado</th><th>Acción</th><th>Detalle</th><th>Tok</th></tr></thead><tbody id="hist"></tbody></table></div>
+  </div>
+</section>
+
+<section class="panel" id="p-projects">
+  <div class="card"><h3>Propuestas de Kiwy (solo Projects)</h3><div class="mut">Si apruebas, yo las ejecuto.</div><div id="props"></div><div id="out" class="mut"></div></div>
+  <div class="card" style="margin-top:10px"><h3>Vista general (compacta)</h3><table><thead><tr><th>Sem</th><th>Proyecto</th><th>Abiertas</th><th>Vencidas</th></tr></thead><tbody id="proy"></tbody></table></div>
+</section>
+
+<section class="panel" id="p-team">
+  <div class="card"><h3>Equipo</h3><div id="members"></div></div>
+  <div class="card" style="margin-top:10px"><h3>Solicitudes externas detectadas</h3><div id="rnote" class="mut"></div><table><thead><tr><th>Quién</th><th>Mensaje</th></tr></thead><tbody id="relay"></tbody></table></div>
+</section>
+
+<section class="panel" id="p-skills">
+  <div class="card"><h3>Skills (click para detalle)</h3><input id="q" placeholder="Buscar skill..."/><div id="smeta" class="mut" style="margin:6px 0"></div><div class="two"><div id="slist"></div><div id="sdetail" class="row mut">Selecciona un skill.</div></div></div>
+</section>
+</main></div>
+<script>
+let D=null;const esc=s=>(s||'').replace(/[&<>]/g,m=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[m]));
+function show(p){document.querySelectorAll('.n').forEach(x=>x.classList.toggle('a',x.dataset.p===p));document.querySelectorAll('.panel').forEach(x=>x.classList.remove('on'));document.getElementById('p-'+p).classList.add('on')}
+async function approve(id){out.textContent='Ejecutando...';const r=await fetch('/api/approve',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({actionId:id})});const j=await r.json();out.innerHTML=(j.ok?'<span class="ok">✅ Ejecutado</span>':'<span class="bad">⚠️ Error</span>')+' · '+esc(j.stdout||j.stderr||'');await load()}
+function renderSkills(q=''){const arr=(D.skills.all||[]).filter(s=>`${s.name} ${s.description}`.toLowerCase().includes(q.toLowerCase()));smeta.textContent=`${(D.skills.ready||[]).length} ready / ${(D.skills.all||[]).length} total`;slist.innerHTML=arr.map((s,i)=>`<div class='row' data-i='${i}' style='cursor:pointer'><b>${esc(s.name)}</b><div class='mut'>${esc((s.description||'').slice(0,80))}</div></div>`).join('');document.querySelectorAll('#slist .row').forEach(el=>el.onclick=()=>{const s=arr[Number(el.dataset.i)];sdetail.innerHTML=`<b>${esc(s.name)}</b><br><br>${esc(s.description||'')}<br><br><span class='mut'>Estado: ${s.status} · Fuente: ${esc(s.source||'n/a')}</span>`})}
+function render(){st.textContent=`Estado PM: ${D.pm.status} · ${D.generated_at_utc}`;sum.textContent=D.pm.summary;
+  top.innerHTML=[['Crons OK',D.automation.cron_ok],['Crons Error',D.automation.cron_error],['Abiertas',D.ops.kpis.abiertas],['Vencidas',D.ops.kpis.vencidas_operativas],['Bloqueadas',D.ops.kpis.bloqueadas],['Reuniones',D.meetings.processed_count],['Agentes',D.agents.total],['Tokens',D.tokens.total_tokens_recent]].map(([k,v])=>`<div class='card'><div class='k'>${k}</div><div class='v'>${v}</div></div>`).join('');
+  tokMeta.textContent=`Input: ${D.tokens.input_tokens_recent} · Output: ${D.tokens.output_tokens_recent}`;
+  const max=Math.max(1,...(D.tokens.by_activity||[]).map(x=>x.total_tokens||0));
+  tokRows.innerHTML=(D.tokens.by_activity||[]).slice(0,8).map(t=>`<div class='row'><div style='display:flex;justify-content:space-between'><span>${esc(t.job)}</span><b>${(t.total_tokens||0).toLocaleString()}</b></div><div class='bar'><span style='width:${Math.round((t.total_tokens||0)/max*100)}%'></span></div></div>`).join('');
+  hist.innerHTML=(D.automation.history||[]).slice(0,18).map(h=>`<tr><td class='${h.status==='ok'?'ok':'bad'}'>${h.status==='ok'?'✅':'⚠️'} ${h.status}</td><td>${esc(h.job)}</td><td>${esc(h.detail||'')}</td><td>${(h.tokens||0).toLocaleString()}</td></tr>`).join('');
+  props.innerHTML=(D.pm.proposals||[]).map(p=>`<div class='row'><b>${esc(p.title)}</b><div class='mut'>${esc(p.why)} · ${esc(p.impact)}</div><button class='btn2' onclick="approve('${p.id}')">Aprobar y ejecutar</button></div>`).join('');
+  proy.innerHTML=(D.ops.projects||[]).slice(0,10).map(p=>`<tr><td>${p.semaforo}</td><td>${esc(p.nombre)}</td><td>${p.abiertas}</td><td>${p.vencidas}</td></tr>`).join('');
+  members.innerHTML=(D.team.members||[]).map(m=>`<div class='row'><b>${esc(m.name)}</b><div class='mut'>ID: ${m.id}</div></div>`).join('');
+  rnote.textContent=D.team.conversations.note||'';
+  relay.innerHTML=(D.team.conversations.relay_requests||[]).slice(0,20).map(r=>`<tr><td>${esc(r.from)}</td><td>${esc(r.message)}</td></tr>`).join('')||'<tr><td colspan="2">Sin solicitudes externas en log local.</td></tr>';
+  renderSkills('');
+}
+async function load(){const r=await fetch('/api/summary?_='+Date.now());const j=await r.json();D=j.data;render()}
+document.querySelectorAll('[data-p]').forEach(b=>b.onclick=()=>show(b.dataset.p));t.onclick=()=>app.classList.toggle('c');document.addEventListener('input',e=>{if(e.target.id==='q')renderSkills(e.target.value)});load();
+</script></body></html>

--- a/v1/refresh_hq.py
+++ b/v1/refresh_hq.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+import json
+import os
+import re
+import subprocess
+from datetime import datetime, timezone
+
+ROOT = "/home/ubuntu/.openclaw/workspace"
+OUT = os.path.join(ROOT, "hq", "v1", "data", "summary.json")
+MEET_STATE = os.path.join(ROOT, "qualiver", "state", "google_record_meetings_state.json")
+HEARTBEAT = os.path.join(ROOT, "HEARTBEAT.md")
+OPS_SCRIPT = os.path.join(ROOT, "qualiver", "qualiver_ops_report.py")
+
+
+def run(cmd: str) -> str:
+    p = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    return p.stdout if p.returncode == 0 else ""
+
+
+def parse_json_cmd(cmd: str, fallback=None):
+    txt = run(cmd).strip()
+    if not txt:
+        return fallback if fallback is not None else {}
+    try:
+        return json.loads(txt)
+    except Exception:
+        return fallback if fallback is not None else {}
+
+
+def parse_ops(text):
+    out = {"kpis": {}, "projects": [], "critical_tasks": []}
+    m = re.search(r"KPIs:\s*total=(\d+)\s*\|\s*abiertas=(\d+)\s*\|\s*vencidas_operativas=(\d+)\s*\|\s*validando=(\d+)\s*\|\s*validando_fuera_plazo=(\d+)\s*\|\s*bloqueadas=(\d+)", text)
+    if m:
+        out["kpis"] = {
+            "total": int(m.group(1)), "abiertas": int(m.group(2)), "vencidas_operativas": int(m.group(3)),
+            "validando": int(m.group(4)), "validando_fuera_plazo": int(m.group(5)), "bloqueadas": int(m.group(6)),
+        }
+
+    sem_block = text.split("Semáforo por proyecto (top 8 por carga):")
+    if len(sem_block) > 1:
+        part = sem_block[1].split("Semáforo por meta", 1)[0]
+        for line in part.splitlines():
+            line = line.strip()
+            if not line.startswith("-"):
+                continue
+            pm = re.match(r"-\s*(\S+)\s+(.*?)\s*\|\s*(.*?)\s*\|\s*abiertas=(\d+)\s*\|\s*vencidas_operativas=(\d+)\s*\|\s*bloqueadas=(\d+)\s*\|\s*validando=(\d+)", line)
+            if pm:
+                out["projects"].append({
+                    "semaforo": pm.group(1), "codigo": pm.group(2), "nombre": pm.group(3),
+                    "abiertas": int(pm.group(4)), "vencidas": int(pm.group(5)), "bloqueadas": int(pm.group(6)), "validando": int(pm.group(7)),
+                })
+
+    crit_block = text.split("Tareas críticas (top 10, excluye Validando):")
+    if len(crit_block) > 1:
+        for line in crit_block[1].splitlines():
+            line = line.strip()
+            if line.startswith("-"):
+                out["critical_tasks"].append(line[2:])
+
+    return out
+
+
+def parse_skills(text: str):
+    skills = []
+    for line in text.splitlines():
+        if not line.startswith("│") or ("✓ ready" not in line and "✗ missing" not in line):
+            continue
+        parts = [p.strip() for p in line.split("│")]
+        if len(parts) < 5:
+            continue
+        skills.append({
+            "status": "ready" if "✓" in parts[1] else "missing",
+            "name": parts[2], "description": parts[3], "source": parts[4], "installedLocal": False,
+        })
+    return skills
+
+
+def scan_local_private_skills():
+    base = os.path.join(ROOT, "skills", "private")
+    found = []
+    if not os.path.isdir(base):
+        return found
+    for slug in sorted(os.listdir(base)):
+        sk = os.path.join(base, slug, "SKILL.md")
+        if not os.path.isfile(sk):
+            continue
+        found.append({"status": "ready", "name": slug, "description": "Local private skill", "source": "local-private", "installedLocal": True})
+    return found
+
+
+def collect_token_activity(enabled_jobs):
+    activity, ti, to, tt = [], 0, 0, 0
+    for j in enabled_jobs:
+        runs = parse_json_cmd(f"openclaw cron runs --id {j.get('id')}", fallback={}).get("entries", [])
+        recent = [e for e in runs[:10] if e.get("usage")]
+        it = sum(int(e.get("usage", {}).get("input_tokens", 0)) for e in recent)
+        ot = sum(int(e.get("usage", {}).get("output_tokens", 0)) for e in recent)
+        tot = sum(int(e.get("usage", {}).get("total_tokens", 0)) for e in recent)
+        if tot > 0:
+            activity.append({"job": j.get("name"), "jobId": j.get("id"), "input_tokens": it, "output_tokens": ot, "total_tokens": tot})
+            ti += it; to += ot; tt += tot
+    activity.sort(key=lambda x: x["total_tokens"], reverse=True)
+    return {"total_tokens_recent": tt, "input_tokens_recent": ti, "output_tokens_recent": to, "by_activity": activity[:12]}
+
+
+def collect_history(enabled_jobs, limit=40):
+    items = []
+    for j in enabled_jobs:
+        runs = parse_json_cmd(f"openclaw cron runs --id {j.get('id')}", fallback={}).get("entries", [])
+        for e in runs[:8]:
+            u = e.get("usage", {}) or {}
+            items.append({
+                "ts": e.get("ts", 0), "job": j.get("name"), "status": e.get("status", "unknown"),
+                "tokens": int(u.get("total_tokens", 0) or 0),
+                "detail": (e.get("summary") or e.get("error") or "").replace("\n", " ")[:200],
+            })
+    items.sort(key=lambda x: x.get("ts", 0), reverse=True)
+    return items[:limit]
+
+
+def scan_relay_requests(max_items=20):
+    findings = []
+    for name in os.listdir(ROOT):
+        if not name.endswith(".jsonl"):
+            continue
+        p = os.path.join(ROOT, name)
+        try:
+            lines = open(p, "r", encoding="utf-8").readlines()[-300:]
+        except Exception:
+            continue
+        for ln in lines:
+            if "RELAY de" not in ln:
+                continue
+            m = re.search(r"RELAY de\s*\[?([+\d]+)\]?\s*:\s*(.+)$", ln)
+            if m:
+                findings.append({"from": m.group(1), "message": m.group(2)[:180]})
+            else:
+                findings.append({"from": "desconocido", "message": ln[:180]})
+            if len(findings) >= max_items:
+                return findings
+    return findings
+
+
+def build_recommendations(kpis, errored):
+    recs = []
+    if kpis.get("vencidas_operativas", 0) >= 10:
+        recs.append({"id": "run_ops_report_now", "title": "Correr corte operativo ahora", "why": "Hay muchas vencidas operativas.", "impact": "Te doy un plan de choque actualizado para hoy."})
+    if errored:
+        recs.append({"id": "rerun_failed_crons", "title": "Reintentar automatizaciones con error", "why": f"Hay {len(errored)} cron(s) en error.", "impact": "Reducimos ruido y recuperamos flujo automático."})
+    recs.append({"id": "run_meeting_monitor_now", "title": "Revisar reuniones nuevas ahora", "why": "Garantizar que no se perdió ninguna acción crítica.", "impact": "Se crean tareas y resumen inmediato si hay novedades."})
+    return recs[:4]
+
+
+def main():
+    os.makedirs(os.path.dirname(OUT), exist_ok=True)
+    cron_data = parse_json_cmd("openclaw cron list --json", fallback={"jobs": []})
+    jobs = cron_data.get("jobs", [])
+    enabled = [j for j in jobs if j.get("enabled")]
+    errored = [j for j in enabled if j.get("state", {}).get("lastStatus") == "error"]
+
+    ops = parse_ops(run(f"python3 {OPS_SCRIPT}"))
+    kpis = ops.get("kpis", {})
+    meetings = json.load(open(MEET_STATE, "r", encoding="utf-8")) if os.path.exists(MEET_STATE) else {}
+    hb = open(HEARTBEAT, "r", encoding="utf-8").read() if os.path.exists(HEARTBEAT) else ""
+
+    skills = parse_skills(run("openclaw skills list"))
+    names = {s["name"].lower() for s in skills}
+    for lp in scan_local_private_skills():
+        if lp["name"].lower() not in names:
+            skills.append(lp)
+
+    agents = sorted(set([j.get("agentId", "main") for j in jobs]))
+    token_activity = collect_token_activity(enabled)
+    history = collect_history(enabled, 50)
+    relay_requests = scan_relay_requests(20)
+
+    pm_status = "En control"
+    if kpis.get("vencidas_operativas", 0) >= 15 or kpis.get("bloqueadas", 0) >= 4:
+        pm_status = "Atención alta"
+
+    data = {
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "hq_version": "v2-pm",
+        "pm": {
+            "title": "Project Management · Qualiver",
+            "status": pm_status,
+            "summary": f"Abiertas: {kpis.get('abiertas', 0)} · Vencidas operativas: {kpis.get('vencidas_operativas', 0)} · Bloqueadas: {kpis.get('bloqueadas', 0)}",
+            "proposals": build_recommendations(kpis, errored),
+        },
+        "tokens": token_activity,
+        "automation": {
+            "cron_total": len(jobs), "cron_enabled": len(enabled), "cron_error": len(errored),
+            "cron_ok": max(0, len(enabled) - len(errored)), "history": history,
+        },
+        "ops": ops,
+        "meetings": {"last_review_utc": meetings.get("last_review_utc"), "processed_count": len(meetings.get("processed_docs", [])), "last_docs": meetings.get("processed_docs", [])[-8:]},
+        "heartbeat": {"configured": bool(hb.strip()), "has_meeting_flow": "Drive — Shared Kiwy (Reuniones)" in hb},
+        "skills": {"all": skills, "ready": [s for s in skills if s.get("status") == "ready"], "missing": [s for s in skills if s.get("status") == "missing"]},
+        "agents": {"ids": agents, "total": len(agents), "jobs_by_agent": {aid: len([j for j in jobs if j.get("agentId") == aid]) for aid in agents}},
+        "team": {
+            "members": [
+                {"id": "1152456698", "name": "Juan Camilo Sierra Ramirez"},
+                {"id": "1039451589", "name": "Natalia Jimenez"},
+                {"id": "525936", "name": "Guillermo Souto"},
+                {"id": "1003059949", "name": "Jose Ortiz"},
+                {"id": "1013457030", "name": "Yenifer Mazo"}
+            ],
+            "conversations": {
+                "status": "partial",
+                "note": "Vista parcial de solicitudes externas detectadas por relay/log local.",
+                "relay_requests": relay_requests,
+            }
+        },
+    }
+
+    with open(OUT, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+    print(f"HQ snapshot actualizado: {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/v1/server.py
+++ b/v1/server.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import json
+import os
+import subprocess
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+
+BASE = "/home/ubuntu/.openclaw/workspace/hq/v1"
+SUMMARY = os.path.join(BASE, "data", "summary.json")
+
+ACTION_MAP = {
+    "run_ops_report_now": "python3 /home/ubuntu/.openclaw/workspace/qualiver/qualiver_ops_report.py | head -n 80",
+    "rerun_failed_crons": "python3 /home/ubuntu/.openclaw/workspace/hq/v1/tools/rerun_failed_crons.py",
+    "run_meeting_monitor_now": "openclaw cron run --id 72fb1bef-ead1-402a-86f3-955966861ba1 --force",
+}
+
+class Handler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=BASE, **kwargs)
+
+    def _send_json(self, code, obj):
+        b = json.dumps(obj, ensure_ascii=False).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(b)))
+        self.end_headers()
+        self.wfile.write(b)
+
+    def do_GET(self):
+        if self.path.startswith("/api/summary"):
+            if not os.path.exists(SUMMARY):
+                return self._send_json(404, {"ok": False, "error": "summary not found"})
+            data = json.load(open(SUMMARY, "r", encoding="utf-8"))
+            return self._send_json(200, {"ok": True, "data": data})
+        return super().do_GET()
+
+    def do_POST(self):
+        if self.path.startswith("/api/approve"):
+            ln = int(self.headers.get("Content-Length", "0"))
+            raw = self.rfile.read(ln) if ln > 0 else b"{}"
+            try:
+                body = json.loads(raw.decode("utf-8"))
+            except Exception:
+                body = {}
+            aid = body.get("actionId")
+            cmd = ACTION_MAP.get(aid)
+            if not cmd:
+                return self._send_json(400, {"ok": False, "error": "unknown action"})
+            p = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+            return self._send_json(200, {
+                "ok": p.returncode == 0,
+                "actionId": aid,
+                "stdout": (p.stdout or "")[:1200],
+                "stderr": (p.stderr or "")[:1200],
+                "code": p.returncode,
+            })
+        return self._send_json(404, {"ok": False, "error": "not found"})
+
+if __name__ == "__main__":
+    os.makedirs(os.path.join(BASE, "data"), exist_ok=True)
+    httpd = ThreadingHTTPServer(("0.0.0.0", 3340), Handler)
+    print("HQ server running on :3340")
+    httpd.serve_forever()

--- a/v1/tools/rerun_failed_crons.py
+++ b/v1/tools/rerun_failed_crons.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+import json, subprocess
+
+raw = subprocess.run("openclaw cron list --json", shell=True, capture_output=True, text=True)
+if raw.returncode != 0:
+    print("No se pudo listar crons")
+    raise SystemExit(1)
+
+jobs = json.loads(raw.stdout).get("jobs", [])
+failed = [j for j in jobs if j.get("enabled") and j.get("state", {}).get("lastStatus") == "error"]
+for j in failed:
+    jid = j.get("id")
+    name = j.get("name")
+    r = subprocess.run(f"openclaw cron run --id {jid} --force", shell=True, capture_output=True, text=True)
+    print(f"{name}: {'OK' if r.returncode==0 else 'FAIL'}")
+
+if not failed:
+    print("Sin crons fallidos")


### PR DESCRIPTION
## Resumen
- mejora visual de Kiwy HQ (tema claro con acentos neon sutiles)
- navegación por tabs (Overview / Projects / Team / Skills)
- propuestas de Kiwy solo en tab Projects con aprobación/ejecución
- mejoras de tokens recientes e historial operativo
- skills clickeables con panel de detalle
- sección Team con miembros + solicitudes externas detectadas
- agrega PDR.md con alcance, arquitectura, roadmap y KPIs

## Archivos clave
- v1/index.html
- v1/refresh_hq.py
- v1/server.py
- v1/tools/rerun_failed_crons.py
- PDR.md

## Notas
- endpoint de aprobación: POST /api/approve
- resumen para UI: GET /api/summary
- puerto local: 3340
